### PR TITLE
fix: rstrip feature mask

### DIFF
--- a/GPUmodules/env.py
+++ b/GPUmodules/env.py
@@ -203,7 +203,7 @@ class GutConst:
         """
         try:
             with open(self.featuremask) as fm_file:
-                self.amdfeaturemask = int(fm_file.readline())
+                self.amdfeaturemask = int(fm_file.readline().rstrip(), 0)
         except OSError as err:
             LOGGER.debug('Could not read AMD Featuremask [%s]', err)
             self.amdfeaturemask = 0


### PR DESCRIPTION
* Also add base to int() so the mask is interpreted exactly as a code literal
* Fixes #102 